### PR TITLE
Add support for R markdown code blocks

### DIFF
--- a/after/ftplugin/rmarkdown.vim
+++ b/after/ftplugin/rmarkdown.vim
@@ -1,0 +1,2 @@
+command! -bang -buffer -nargs=? EvalBlock call medieval#eval(<bang>0, <f-args>)
+let b:undo_ftplugin = get(b:, 'undo_ftplugin', '') . '|delc EvalBlock'

--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -124,14 +124,14 @@ function! medieval#eval(bang, ...)
 
     let view = winsaveview()
     let line = line('.')
-    let start = search('^\s*[`~]\{3,}\s*\%({\.\)\?\a\+', 'bnW')
+    let start = search('^\s*[`~]\{3,}\s*\%({\.\)\?{\?\a\+,\?.*}\?', 'bnW')
     if !start
         return
     endif
 
     call cursor(start, 1)
     let [fence, lang] = matchlist(getline(start),
-                \ '^\s*\([`~]\{3,}\)\s*\%({\.\)\?\(\a\+\)\?')[1:2]
+                \ '^\s*\([`~]\{3,}\)\s*\%({\.\)\?{\?\(\a\+\)\?,\?.*}\?')[1:2]
     let end = search('^\s*' . fence . '\s*$', 'nW')
     let langidx = index(map(copy(g:medieval_langs), 'split(v:val, "=")[0]'), lang)
 


### PR DESCRIPTION
R markdown code blocks can look like this:

```markdown
```{r}
```

or this:

```markdown
```{r, eval=FALSE...}
```