### PR TITLE
Support code blocks with an empty language

### DIFF
--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -229,7 +229,7 @@ function! medieval#eval(bang, ...) abort
         return s:error('Closing fence not found')
     endif
 
-    let langidx = index(map(copy(g:medieval_langs), 'split(v:val, "=")[0]'), lang)
+    let langidx = index(map(copy(g:medieval_langs), 'split(v:val, "=", 1)[0]'), lang)
     if langidx < 0
         call winrestview(view)
         echo '''' . lang . ''' not found in g:medieval_langs'


### PR DESCRIPTION
I have found it useful, and think others may as well, to be able to have code blocks without a specified language to still be executable.

One example is that I am using this with a config of `let g:medieval_langs = ['=cat']` which enables writing the code block, with an appropriate target, to a file.