### PR TITLE
Correctly handle missing trailing newline

### DIFF
--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -93,13 +93,21 @@ function! s:createblock(start, name, fence) abort
     call append(a:start, ['', '<!-- name: ' . a:name . ' -->', a:fence, a:fence])
 endfunction
 
+function! s:extend(list, val)
+    let data = a:val
+    if data[-1] == ''
+        let data = data[:-2]
+    end
+    return extend(a:list, data)
+endfunction
+
 " Wrapper around job start functions for both neovim and vim
 function! s:jobstart(cmd, cb) abort
     let output = []
     if exists('*jobstart')
         call jobstart(a:cmd, {
-                    \ 'on_stdout': {_, data, ... -> extend(output, data[:-2])},
-                    \ 'on_stderr': {_, data, ... -> extend(output, data[:-2])},
+                    \ 'on_stdout': {_, data, ... -> s:extend(output, data)},
+                    \ 'on_stderr': {_, data, ... -> s:extend(output, data)},
                     \ 'on_exit': {... -> a:cb(output)},
                     \ 'stdout_buffered': 1,
                     \ 'stderr_buffered': 1,


### PR DESCRIPTION
Nvim's jobstart callback appends an empty '' element to the buffered
output list indicating a trailing newline. However, if the output does
not have a trailing newline there is no empty element, so it is
incorrect to unconditionally remove the last element.

Instead, explicitly check that the final element is empty before
removing it.

Closes #11.
