### PR TITLE
feat: add 'after' callback

### DIFF
--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -217,6 +217,10 @@ function! s:callback(context, output) abort
         setlocal buftype=nofile bufhidden=delete nobuflisted noswapfile winfixheight
         wincmd p
     endif
+
+    if has_key(opts, 'after')
+        call opts.after(a:context, a:output)
+    endif
 endfunction
 
 function! medieval#eval(...) abort

--- a/doc/medieval.txt
+++ b/doc/medieval.txt
@@ -259,6 +259,13 @@ medieval#eval({target}[, {opts})
 				as a list of lines. Modifications to the
 				output list will affect what is written to the
 				target block.
+		  after:	(function) A function to be called when
+				evaluation completes, but after the output is
+				written to the target block. The function
+				accepts two arguments: a "context" |Dict|
+				containing the parameters used to evaluate the
+				block and the result of the block evaluation
+				as a list of lines.
 
 		Example: >
 
@@ -271,9 +278,14 @@ medieval#eval({target}[, {opts})
 			    let a:ctx.start_time = reltime()
 			endfunction
 
+			function! s:after(ctx, input)
+			    echo "Target has been updated."
+			endfunction
+
 			call medieval#eval('',
 				\ #{setup: function('s:setup'),
-				\   complete: function('s:complete')})
+				\   complete: function('s:complete'),
+				\   after: function('s:after')})
 <
 							*g:medieval_langs*
 Medieval will only attempt to execute code blocks in languages explicitly


### PR DESCRIPTION
This commit adds an `'after'` callback similar to the existing `'setup'` and `'complete'` callbacks. `'after'` will be executed when the evaluation started by `medieval#eval` is finished and the target has been updated.

The PR should resolve #13.