### PR TITLE
Make source fence patterns configurable

### DIFF
--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -42,7 +42,7 @@ endfunction
 "     ```
 "     ```
 function! s:findblock(name) abort
-    let fences = extend(s:fences, get(g:, 'medieval_fences', []))
+    let fences = s:fences + get(g:, 'medieval_fences', [])
     let fencepat = s:fencepat(fences)
 
     let curpos = getcurpos()[1:]

--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -1,4 +1,4 @@
-let s:fences = [#{start: '\([`~]\{3,}\)\s*\%({\s*\.\?\)\?\(\a\+\)\?', end: '\1', lang: 2,}, #{start: '\$\$'}]
+const s:fences = [#{start: '\([`~]\{3,}\)\s*\%({\s*\.\?\)\?\(\a\+\)\?', end: '\1', lang: 2,}, #{start: '\$\$'}]
 let s:opts = ['name', 'target', 'require', 'tangle']
 let s:optspat = '\(' . join(s:opts, '\|') . '\):\s*\([0-9A-Za-z_+.$#&/-]\+\)'
 


### PR DESCRIPTION
Resolves: https://github.com/gpanders/vim-medieval/issues/15

This makes "source" code blocks configurable as well as "target" code blocks.

For example, to support Vimwiki style code blocks:

```
{{{sh

}}}
```

one can add the following to `g:medieval_fences`:

```vim
let g:medieval_fences = [#{start: '{{{\(\a\+\)', end: '}}}', lang: 1 }]
```

The `start` pattern is the pattern to match for the start of the fence. It must contain a capture group matching the language of the block. The additional `lang` property indicates the index of that capture group.

**TODO**

- [ ] Docs
- [ ] Regression testing

cc @MartyLake
