### PR TITLE
Fix bug with configurable fences

### DIFF
--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -235,7 +235,7 @@ function! medieval#eval(...) abort
 
     let view = winsaveview()
     let line = line('.')
-    let fences = filter(extend(s:fences, get(g:, 'medieval_fences', [])), 'has_key(v:val, "lang")')
+    let fences = filter((s:fences + get(g:, 'medieval_fences', [])), 'has_key(v:val, "lang")')
     let fencepat = s:fencepat(fences)
     let start = search(fencepat, 'bcnW')
     if !start


### PR DESCRIPTION
not sure why I did not encounter it before, it is the same type of issue fixed by https://github.com/gpanders/vim-medieval/pull/20 where `extend` is used but `+` should be used instead.