### PR TITLE
Add range support to :EvalBlock

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Test
+on:
+  push:
+    branches: [master]
+  pull_request:
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check Vim
+        run: which vim && vim --version | head -1
+      - name: Run tests
+        run: ./run-test.sh

--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -244,7 +244,12 @@ function! medieval#evalrange(line1, line2, target) abort
         for fence in fences
             let matches = matchlist(line, fence.start)
             if !empty(matches) && matches[fence.lang] !=# ''
-                call add(blocks, lnum)
+                " Skip named blocks without a target — these are output
+                " destinations or dependency blocks, not source blocks
+                let opts = s:parseopts(&filetype, lnum - 1)
+                if !has_key(opts, 'name') || has_key(opts, 'target')
+                    call add(blocks, lnum)
+                endif
                 break
             endif
         endfor

--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -108,7 +108,7 @@ endfunction
 " Wrapper around job start functions for both neovim and vim
 function! s:jobstart(cmd, cb) abort
     let output = []
-    if exists('*jobstart')
+    if !get(g:, 'medieval_sync') && exists('*jobstart')
         call jobstart(a:cmd, {
                     \ 'on_stdout': {_, data, ... -> s:extend(output, data)},
                     \ 'on_stderr': {_, data, ... -> s:extend(output, data)},
@@ -116,7 +116,7 @@ function! s:jobstart(cmd, cb) abort
                     \ 'stdout_buffered': 1,
                     \ 'stderr_buffered': 1,
                     \ })
-    elseif exists('*job_start')
+    elseif !get(g:, 'medieval_sync') && exists('*job_start')
         call job_start(a:cmd, {
                     \ 'callback': {_, data -> add(output, data)},
                     \ 'exit_cb': {... -> a:cb(output)},

--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -227,6 +227,39 @@ function! s:callback(context, output) abort
     endif
 endfunction
 
+function! medieval#evalrange(line1, line2, target) abort
+    if !exists('g:medieval_langs')
+        call s:error('g:medieval_langs is unset')
+        return
+    endif
+
+    let fences = filter((s:fences + get(g:, 'medieval_fences', [])), 'has_key(v:val, "lang")')
+    let view = winsaveview()
+
+    " Collect opening fence lines with a language within the range
+    let blocks = []
+    let lnum = a:line1
+    while lnum <= a:line2
+        let line = getline(lnum)
+        for fence in fences
+            let matches = matchlist(line, fence.start)
+            if !empty(matches) && matches[fence.lang] !=# ''
+                call add(blocks, lnum)
+                break
+            endif
+        endfor
+        let lnum += 1
+    endwhile
+
+    " Evaluate each block
+    for blnum in blocks
+        call cursor(blnum, 1)
+        call medieval#eval(a:target)
+    endfor
+
+    call winrestview(view)
+endfunction
+
 function! medieval#eval(...) abort
     if !exists('g:medieval_langs')
         call s:error('g:medieval_langs is unset')

--- a/autoload/medieval.vim
+++ b/autoload/medieval.vim
@@ -280,6 +280,27 @@ function! medieval#eval(...) abort
         return
     endif
 
+    " If cursor is in a named destination block, find and evaluate its source
+    let opts = s:parseopts(&filetype, start - 1)
+    if has_key(opts, 'name') && !has_key(opts, 'target')
+        call cursor(1, 1)
+        let pat = get(get(g:, 'medieval_option_pat', {}), &filetype, s:optionpat)
+        while 1
+            let srcline = search(pat . s:optspat, 'cW')
+            if !srcline
+                call winrestview(view)
+                return s:error('No source block targeting "' . opts.name . '"')
+            endif
+            call cursor(srcline + 1, 1)
+            if getline(srcline) =~# '\<target:\s*' . opts.name
+                break
+            endif
+        endwhile
+        call call('medieval#eval', a:000)
+        call winrestview(view)
+        return
+    endif
+
     call cursor(start, 1)
 
     let lang = ''

--- a/doc/medieval.txt
+++ b/doc/medieval.txt
@@ -20,6 +20,18 @@ By placing your cursor anywhere in the code block above and running
 You can also redirect the output of the evaluation into a register using
 |:EvalBlock| @{0-9a-z".=*+}.
 
+You can also use a range to evaluate multiple blocks at once. For example: >
+
+	:%EvalBlock
+<
+evaluates all code blocks in the entire buffer. Similarly: >
+
+	:10,50EvalBlock
+<
+evaluates all code blocks between lines 10 and 50. A visual selection also
+works: select lines, then run |:EvalBlock|. Each block uses its own options
+(target, require, etc.).
+
 							*medieval-target*
 You can also send the output of evaluation into another code block, allowing
 you to do a primitive style of literate programming. You can accomplish this
@@ -289,7 +301,14 @@ medieval#eval({target}[, {opts})
 				\   complete: function('s:complete'),
 				\   after: function('s:after')})
 <
-							*g:medieval_langs*
+							*medieval#evalrange()*
+medieval#evalrange({line1}, {line2}, {target})
+		Evaluate all code blocks between {line1} and {line2}.
+		{target} is passed to |medieval#eval()| for each block. Use
+		an empty string to let each block use its own target. Use
+		"self" to replace each block's contents with its output.
+
+						*g:medieval_langs*
 Medieval will only attempt to execute code blocks in languages explicitly
 listed in the variable |g:medieval_langs|. The structure of this variable is a
 list of strings corresponding to whitelisted languages that can be

--- a/plugin/medieval.vim
+++ b/plugin/medieval.vim
@@ -3,8 +3,10 @@ if get(g:, 'loaded_medieval')
 endif
 let g:loaded_medieval = 1
 
-command! -bang -nargs=? EvalBlock
-            \ if <bang>0 |
+command! -bang -range -nargs=? EvalBlock
+            \ if <range> > 0 |
+            \   call medieval#evalrange(<line1>, <line2>, <bang>0 ? 'self' : <q-args>) |
+            \ elseif <bang>0 |
             \   call medieval#eval('self') |
             \ else |
             \   call medieval#eval(<q-args>) |

--- a/run-test.sh
+++ b/run-test.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+cd "$(dirname "$0")"
+
+if [ ! -d test/vader.vim ]; then
+  git clone --depth 1 https://github.com/junegunn/vader.vim test/vader.vim
+fi
+
+vim --not-a-term -Nu test/vimrc '+Vader! test/*.vader' 2>&1 | \
+  perl -pe 's/\e[\[\]>][0-9;?]*[a-zA-Z]//g; s/\e[>=]//g' | \
+  grep -E '(^Vader|^Starting|^  Starting|^    \(|^  Success|^Success|^Elapsed)'

--- a/test/medieval.vader
+++ b/test/medieval.vader
@@ -35,6 +35,26 @@ Execute (Eval source block with named target):
 Then (Output written to named target block):
   AssertEqual 'computed', getline(8)
 
+" === EvalBlock from destination block redirects to source ===
+
+Given markdown (EvalBlock in destination block evaluates its source):
+  <!-- target: dest -->
+  ```sh
+  echo "from source"
+  ```
+
+  <!-- name: dest -->
+  ```
+  old output
+  ```
+
+Execute (Cursor in destination block):
+  8
+  EvalBlock
+
+Then (Source block was evaluated, output written to destination):
+  AssertEqual 'from source', getline(8)
+
 " === :EvalBlock {target} — explicit target argument (doc line 65) ===
 
 Given markdown (Explicit target argument overrides header):

--- a/test/medieval.vader
+++ b/test/medieval.vader
@@ -208,3 +208,105 @@ Then (Source tangled to file and executed):
 
 After:
   call delete('_medieval_test_tangle.sh')
+
+" === Range support ===
+
+Before:
+  let g:medieval_langs = ['sh']
+
+Given markdown (Two blocks both targeting self):
+  <!-- target: self -->
+  ```sh
+  echo "first"
+  ```
+
+  <!-- target: self -->
+  ```sh
+  echo "second"
+  ```
+
+Execute (Range eval replaces all blocks):
+  %EvalBlock!
+
+
+Then (Both blocks replaced):
+  AssertEqual 'first', getline(3)
+  AssertEqual 'second', getline(8)
+
+Given markdown (Partial range evaluates only covered blocks):
+  <!-- target: self -->
+  ```sh
+  echo "in range"
+  ```
+
+  <!-- target: self -->
+  ```sh
+  echo "also in range"
+  ```
+
+  <!-- target: self -->
+  ```sh
+  echo "out of range"
+  ```
+
+Execute (Range covers only first two blocks):
+  1,10EvalBlock!
+
+
+Then (First two blocks evaluated, third unchanged):
+  AssertEqual 'in range', getline(3)
+  AssertEqual 'also in range', getline(8)
+  AssertEqual 'echo "out of range"', getline(13)
+
+Given markdown (No blocks in range):
+  This is just text.
+  No code blocks here.
+
+  ```sh
+  echo "hello"
+  ```
+
+Execute (Range covers only text lines):
+  1,2EvalBlock
+
+
+Then (Buffer is unchanged):
+  AssertEqual 'This is just text.', getline(1)
+  AssertEqual 'No code blocks here.', getline(2)
+  AssertEqual 'echo "hello"', getline(5)
+
+Given markdown (Named target block):
+  <!-- target: output -->
+  ```sh
+  echo "result"
+  ```
+
+  <!-- name: output -->
+  ```
+  ```
+
+Execute (Range eval with named target):
+  %EvalBlock
+
+
+Then (Named target block populated with output):
+  AssertEqual 'result', getline(8)
+
+Given markdown (Closing fences not treated as blocks):
+  ```sh
+  echo "one"
+  ```
+
+  ```sh
+  echo "two"
+  ```
+
+Execute (Range eval only evaluates opening fences):
+  %EvalBlock!
+
+
+Then (Both blocks evaluated correctly):
+  AssertEqual 'one', getline(2)
+  AssertEqual '```', getline(3)
+  AssertEqual 'two', getline(6)
+  AssertEqual '```', getline(7)

--- a/test/medieval.vader
+++ b/test/medieval.vader
@@ -310,3 +310,22 @@ Then (Both blocks evaluated correctly):
   AssertEqual '```', getline(3)
   AssertEqual 'two', getline(6)
   AssertEqual '```', getline(7)
+
+" === Range skips named output blocks ===
+
+Given markdown (Range skips named blocks that are output destinations):
+  <!-- target: out -->
+  ```sh
+  echo "source"
+  ```
+
+  <!-- name: out -->
+  ```sh
+  old output
+  ```
+
+Execute (Range eval should only run the source block):
+  %EvalBlock
+
+Then (Source block output written to named block, named block not executed):
+  AssertEqual 'source', getline(8)

--- a/test/medieval.vader
+++ b/test/medieval.vader
@@ -1,0 +1,210 @@
+Before:
+  let g:medieval_langs = ['sh']
+
+" === :EvalBlock! — target self (doc line 65-79) ===
+
+Given markdown (EvalBlock! replaces block content):
+  ```sh
+  echo "hello"
+  ```
+
+Execute (EvalBlock! replaces block in-place):
+  2
+  EvalBlock!
+
+Then (Output replaces code block content):
+  AssertEqual 'hello', getline(2)
+  AssertEqual '```', getline(3)
+
+" === Named target block (doc line 23-44) ===
+
+Given markdown (Output sent to named target block):
+  <!-- target: result -->
+  ```sh
+  echo "computed"
+  ```
+
+  <!-- name: result -->
+  ```
+  ```
+
+Execute (Eval source block with named target):
+  3
+  EvalBlock
+
+Then (Output written to named target block):
+  AssertEqual 'computed', getline(8)
+
+" === :EvalBlock {target} — explicit target argument (doc line 65) ===
+
+Given markdown (Explicit target argument overrides header):
+  ```sh
+  echo "override"
+  ```
+
+  <!-- name: dest -->
+  ```
+  ```
+
+Execute (Explicit target argument):
+  2
+  EvalBlock dest
+
+Then (Output sent to explicit target, not header target):
+  AssertEqual 'override', getline(7)
+
+" === Info string formats (doc line 81-102) ===
+
+Given markdown (Info string with curly-dot: {.lang}):
+  ```{.sh}
+  echo "dotlang"
+  ```
+
+Execute (EvalBlock! with {.lang} fence):
+  2
+  EvalBlock!
+
+Then (Language parsed from {.lang} format):
+  AssertEqual 'dotlang', getline(2)
+
+Given markdown (Info string with curly: {lang}):
+  ```{sh}
+  echo "curlylang"
+  ```
+
+Execute (EvalBlock! with {lang} fence):
+  2
+  EvalBlock!
+
+Then (Language parsed from {lang} format):
+  AssertEqual 'curlylang', getline(2)
+
+Given markdown (Info string with extra attributes):
+  ``` {.sh .numberLines #my-id}
+  echo "attrs"
+  ```
+
+Execute (EvalBlock! with extra attributes):
+  2
+  EvalBlock!
+
+Then (Language parsed despite extra attributes):
+  AssertEqual 'attrs', getline(2)
+
+" === Tilde fences (doc line 104) ===
+" SKIPPED: ~~~sh resolves end pattern to ~~~, but ~ is a special regex atom
+" in Vim (last substitute string). With no prior :s, this gives E33.
+" This is a pre-existing bug in the fence end-pattern handling.
+
+" === Require — recursive dependencies (doc line 179-201) ===
+
+Given markdown (Recursive require chain):
+  <!-- name: first_name -->
+  ```sh
+  first_name="Gregory"
+  ```
+
+  <!-- name: full_name, require: first_name -->
+  ```sh
+  full_name="$first_name Anders"
+  ```
+
+  <!-- target: greeting, require: full_name -->
+  ```sh
+  echo "Hi, my name is $full_name"
+  ```
+
+Execute (Eval block with recursive require chain):
+  13
+  EvalBlock
+
+Then (All dependencies resolved recursively):
+  AssertEqual 'Hi, my name is Gregory Anders', getline(18)
+
+" === Language alias (doc line 296-302) ===
+
+Given markdown (Language alias sh=bash):
+  ```sh
+  echo "aliased"
+  ```
+
+Before:
+  let g:medieval_langs = ['sh=bash']
+
+Execute (EvalBlock! with aliased language):
+  2
+  EvalBlock!
+
+Then (sh executed via bash alias):
+  AssertEqual 'aliased', getline(2)
+
+After:
+  let g:medieval_langs = ['sh']
+
+" === Register target (doc line 20-21) ===
+
+Before:
+  let g:medieval_langs = ['sh']
+
+Given markdown (Register target stores output in register):
+  ```sh
+  echo "in register"
+  ```
+
+Execute (EvalBlock to register @a):
+  2
+  EvalBlock @a
+
+Then (Output stored in register a):
+  AssertEqual "in register\n", getreg('a')
+
+" === File target (doc line 46-54) ===
+
+Before:
+  let g:medieval_langs = ['sh']
+  if filereadable('_medieval_test_output.txt')
+    throw 'Refusing to run: _medieval_test_output.txt already exists in working directory'
+  endif
+
+Given markdown (File target writes output to file):
+  <!-- target: ./_medieval_test_output.txt -->
+  ```sh
+  echo "file output"
+  ```
+
+Execute (EvalBlock with file target):
+  3
+  EvalBlock
+
+Then (Output written to file):
+  Assert filereadable('_medieval_test_output.txt'), 'Output file should exist'
+  AssertEqual ['file output'], readfile('_medieval_test_output.txt')
+
+After:
+  call delete('_medieval_test_output.txt')
+
+" === Tangle (doc line 203-236) ===
+
+Before:
+  let g:medieval_langs = ['sh']
+  if filereadable('_medieval_test_tangle.sh')
+    throw 'Refusing to run: _medieval_test_tangle.sh already exists in working directory'
+  endif
+
+Given markdown (Tangle writes source to file before executing):
+  <!-- tangle: _medieval_test_tangle.sh -->
+  ```sh
+  echo "tangled"
+  ```
+
+Execute (EvalBlock! with tangle option):
+  3
+  EvalBlock!
+
+Then (Source tangled to file and executed):
+  Assert filereadable('_medieval_test_tangle.sh'), 'Tangle file should exist'
+  AssertEqual ['echo "tangled"'], readfile('_medieval_test_tangle.sh')
+  AssertEqual 'tangled', getline(3)
+
+After:
+  call delete('_medieval_test_tangle.sh')

--- a/test/vimrc
+++ b/test/vimrc
@@ -1,0 +1,7 @@
+set nocompatible
+filetype off
+set runtimepath+=test/vader.vim
+set runtimepath+=.
+filetype plugin indent on
+let g:medieval_langs = ['sh']
+let g:medieval_sync = 1


### PR DESCRIPTION
Closes #23.

:EvalBlock now accepts a range, so :%EvalBlock evaluates all code blocks in the buffer and :10,50EvalBlock evaluates blocks in that range. Visual selections work too.

Each block uses its own options (target, require, tangle, etc.). Blocks are evaluated top-to-bottom. Named output/dependency blocks (those with name: but no target:) are skipped automatically.

Also fixes a pre-existing bug where calling :EvalBlock with the cursor in a destination block would execute the destination's contents instead of finding and evaluating its source block.

Other changes:
- g:medieval_sync option to force synchronous execution (used by tests)
- Vader.vim test suite (18 cases, run with sh run-test.sh)