### PR TITLE
Document existing target block behavior

### DIFF
--- a/doc/medieval.txt
+++ b/doc/medieval.txt
@@ -55,6 +55,23 @@ If you run |:EvalBlock| in the first code block, the second block will become
 	[0, 1, 4, 9, 16]
 	```
 <
+If the named target block already exists, Medieval leaves its fence unchanged
+and only replaces the contents.
+
+That makes it useful when a code block produces Markdown. For example, you can
+create the target block as a `markdown` fence yourself and let Medieval keep
+that fence on subsequent runs:
+>
+	<!-- target: rendered -->
+	```bash
+	printf '# Title\n\nThis is rendered markdown.\n'
+	```
+
+	<!-- name: rendered -->
+	```markdown
+	```
+<
+
 The target of a block can also be a file. If the target name contains a "/"
 character, it is assumed to be a file path. File paths can contain environment
 variables and tilde expansion. Example:
@@ -247,6 +264,7 @@ of the code block, you can use `/dev/null` as the block target:
 >
 	<!-- target: /dev/null tangle: script.py -->
 <
+
 							*medieval#eval()*
 medieval#eval({target}[, {opts})
 		Evaluate the block under the cursor. To replace the contents of

--- a/test/medieval.vader
+++ b/test/medieval.vader
@@ -35,6 +35,28 @@ Execute (Eval source block with named target):
 Then (Output written to named target block):
   AssertEqual 'computed', getline(8)
 
+" === Existing named target keeps its fence ===
+
+Given markdown (Existing target block is not recreated):
+  <!-- target: existing -->
+  ```sh
+  echo 'updated'
+  ```
+
+  <!-- name: existing -->
+  ```text
+  old output
+  ```
+
+Execute (Eval source block writes into existing target):
+  3
+  EvalBlock
+
+Then (Fence stays unchanged and contents are replaced):
+  AssertEqual '```text', getline(7)
+  AssertEqual 'updated', getline(8)
+  AssertEqual '```', getline(9)
+
 " === EvalBlock from destination block redirects to source ===
 
 Given markdown (EvalBlock in destination block evaluates its source):


### PR DESCRIPTION
Hey gpanders, I hope you are doing fine those days.
As I was pondering about using vim-medieval to generate a dashboard a-la obsidian dataviewjs, I wanted to have that bash snippet output markdown.

Turns out, vim-medieval already does that: one only has to change the codeblock language once and subsequent generations will leave it untouched !

So I asked Codex to generate a vader test to make that behaviour explicit.

Let me know what you think of it,
Best,
Marty